### PR TITLE
Syncronize function startup/test start

### DIFF
--- a/MSTestExperiment.Functions/Program.cs
+++ b/MSTestExperiment.Functions/Program.cs
@@ -11,4 +11,18 @@ var host = new HostBuilder()
     })
     .Build();
 
-host.Run();
+Mutex? functionStartup = null;
+try
+{
+    IHostApplicationLifetime hostApplicationLifetime = (IHostApplicationLifetime)host.Services.GetRequiredService(typeof(IHostApplicationLifetime));
+    hostApplicationLifetime.ApplicationStarted.Register(() =>
+    {
+        functionStartup = new(true, "FunctionStartup");
+    });
+
+    host.Run();
+}
+finally
+{
+    functionStartup?.Dispose();
+}

--- a/MSTestExperiment.Tests/UnitTest1.cs
+++ b/MSTestExperiment.Tests/UnitTest1.cs
@@ -3,6 +3,16 @@ namespace MSTestExperiment.Tests
     [TestClass]
     public class UnitTest1
     {
+        [AssemblyInitialize]
+        public static void AssemblyInit(TestContext _)
+        {
+            while (!Mutex.TryOpenExisting("FunctionStartup", out Mutex? _))
+            {
+                Thread.Sleep(200);
+            }
+
+        }
+
         [TestMethod]
         public async Task TestMethod1()
         {

--- a/MSTestExperiment.Tests/UnitTest1.cs
+++ b/MSTestExperiment.Tests/UnitTest1.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.Design;
+
 namespace MSTestExperiment.Tests
 {
     [TestClass]
@@ -6,11 +8,12 @@ namespace MSTestExperiment.Tests
         [AssemblyInitialize]
         public static void AssemblyInit(TestContext _)
         {
-            while (!Mutex.TryOpenExisting("FunctionStartup", out Mutex? _))
+            Mutex? functionStarted = null;
+            while (!Mutex.TryOpenExisting("FunctionStartup", out functionStarted))
             {
                 Thread.Sleep(200);
             }
-
+            functionStarted?.Dispose();
         }
 
         [TestMethod]


### PR DESCRIPTION
Hi @jkdmyrs related to the comment https://devblogs.microsoft.com/dotnet/introducing-ms-test-runner/#comment-20369

You could have guarantee of which process start first but doesn't guarantee that the function is "ready" to accept connections because in the middle we have the jitting, open socket etc...and we're in a preemptive system and we cannot know.

So you can solve your issue in 3 ways

1) Set the open timeout to your `HttpClient` instances
2) Add the health check endpoint inside the function and polling it inside the `AssemblyInitialize`
3) Synchronize client/server and unblock your tests when the function is ready.

This PR implement the third strategy using a `Mutex`.

In this way you can set your "console" projects to start together and have the guarantee that the tests will start when the server is ready.

cc: @Evangelink @nohwnd